### PR TITLE
HOTFIX - Timeouts too low

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY snowflake_data_profiler snowflake_data_profiler
 
 RUN cd snowflake_data_profiler && python -m pip install --upgrade pip && pip install -r requirements.txt
 
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--timeout", "300", "--workers=5", "snowflake_data_profiler.wsgi:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--timeout", "3600", "--workers=5", "snowflake_data_profiler.wsgi:app"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 devserver: venv
-	source ./venv/bin/activate && gunicorn --bind 0.0.0.0:5000 --timeout 300 --workers=5 snowflake_data_profiler.wsgi:app 
+	source ./venv/bin/activate && gunicorn --bind 0.0.0.0:5000 --timeout 3600 --workers=5 snowflake_data_profiler.wsgi:app 
 
 venv:
 	python3 -m venv venv && source ./venv/bin/activate && \

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -12,6 +12,7 @@ server {
     ssl_certificate_key /etc/nginx/certs/server.key;
     server_name profiler.snowflakeinspector.com;
     location / {
+        proxy_read_timeout 3600;
         proxy_pass http://snowflake_data_profiler:5000/;
     }
 }


### PR DESCRIPTION
This PR includes:
- increase of the proxy read timeout for Nginx to 1 hour from 1 minute
- update of gunicorn timeout to 1 hour from 5 minutes (this was probably fine as 5 minutes, but better be safe)